### PR TITLE
Pass command line arguments to packaged program on Windows

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[1.6.0]
+- Exe now passes command line arguments to packaged program
+
 [1.5.1-SNAPSHOT]
 
 [1.5.0]

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = 'org.mini2Dx'
-version = '1.5.1-SNAPSHOT'
+version = '1.6.0'
 description = 'Gradle plugin for bundling your Java application for distribution on Windows, Mac and Linux'
 
 dependencies {

--- a/natives/windows/JavaApplicationConfig.cs
+++ b/natives/windows/JavaApplicationConfig.cs
@@ -53,7 +53,7 @@ namespace parcl
         [XmlElement("includesJre")]
         public bool IncludesJre { get; set; }
 
-        public String ToStartInfoArguments()
+        public String ToStartInfoArguments(String[] runtimeArgs)
         {
             StringBuilder arguments = new StringBuilder();
             if (VmArgs != null)
@@ -73,6 +73,11 @@ namespace parcl
                 {
                     arguments.Append(" " + arg);
                 }
+            }
+
+            foreach (String arg in runtimeArgs)
+            {
+                arguments.Append(" " + arg);
             }
 
             return arguments.ToString();

--- a/natives/windows/Program.cs
+++ b/natives/windows/Program.cs
@@ -47,7 +47,7 @@ namespace parcl
 
                     try
                     {
-                        if (args.Length > 0)
+                        if (args.Length == 1 && args[0].Equals("--example"))
                         {
                             JavaApplicationConfig exampleConfig = new JavaApplicationConfig();
                             exampleConfig.ClassPath = new List<String>();
@@ -85,7 +85,7 @@ namespace parcl
                                 return;
                             }
                         }
-                        process.StartInfo.Arguments = applicationConfig.ToStartInfoArguments();
+                        process.StartInfo.Arguments = applicationConfig.ToStartInfoArguments(args);
                         process.StartInfo.WorkingDirectory = @AppDomain.CurrentDomain.BaseDirectory;
                         process.StartInfo.UseShellExecute = false;
                         process.StartInfo.CreateNoWindow = true;


### PR DESCRIPTION
Thanks for this excellent plugin. The only problem for me is that command line arguments are necessary to my program, and I need to be able to supply them at runtime. My pull request makes command line arguments usable on Windows only.

I noticed that any arguments passed to the `.exe` cause it to create an example config instead of running the packaged program. To allow arguments to be passed to the program, I modified `Program.cs` so that only a single argument, `--example` will trigger this behaviour.

To clarify the new behaviour, here are examples for a program packaged as `TestProgram.exe`:

`.\TestProgram.exe`
_runs packaged program with no args_

`.\TestProgram.exe --example`
_creates example config_

`.\TestProgram.exe --example testarg1`
_runs packaged program with args `--example` and `testarg1`_

`.\TestProgram.exe testarg1 --example `
_runs packaged program with args `testarg1` and `--example`_

`.\TestProgram.exe testarg1`
_runs packaged program with args `testarg1`_

`.\TestProgram.exe testarg1 testarg2`
_runs packaged program with args `testarg1` and `testarg2`_