### PR TITLE
Windows: fix crash when .exe does not have write permissions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[1.7.0]
+- Exe now writes logs to folder in AppData if write permissions are not available for working directory
+
 [1.6.1-SNAPSHOT]
 
 [1.6.0]

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = 'org.mini2Dx'
-version = '1.6.1-SNAPSHOT'
+version = '1.7.0'
 description = 'Gradle plugin for bundling your Java application for distribution on Windows, Mac and Linux'
 
 dependencies {

--- a/natives/windows/FileHandler.cs
+++ b/natives/windows/FileHandler.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace parcl
+{
+    public class FileHandler
+    {
+        private string directory = AppDomain.CurrentDomain.BaseDirectory;
+
+        public FileHandler()
+        {
+            PrepareDirectory();
+        }
+
+        /*
+        Returns the path to a file in the chosen writable directory, when
+        supplied with its name.
+         */
+        public string PathTo(string fileName)
+        {
+            return Path.Combine(directory, fileName);
+        }
+
+        /*
+        Prepares a directory for use by the program. In most cases, this will
+        be the folder containing the .exe; however, a folder with the name of
+        the .exe in AppData\Roaming will be used if the program lacks write
+        permissions to its folder.
+         */
+        private void PrepareDirectory()
+        {
+            if (!HasWritePermissions(directory))
+            {
+                string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                string applicationName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+
+                directory = Path.Combine(appData, applicationName);
+            }
+            Directory.CreateDirectory(directory);
+        }
+
+        /*
+        Checks if the program can write to a directory by attempting to create and
+        immediately delete a file named "test.log".
+
+        Returns whether the program is able to write to the specified folder.
+        */
+        private static bool HasWritePermissions(string folder)
+        {
+            try
+            {
+                using (FileStream stream = File.Create(
+                        Path.Combine(folder, "test.log"), 1, FileOptions.DeleteOnClose)
+                    ) { };
+            }
+            catch
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/natives/windows/Program.cs
+++ b/natives/windows/Program.cs
@@ -38,9 +38,13 @@ namespace parcl
     {
         static void Main(string[] args)
         {
-            using (StreamWriter outputWriter = new StreamWriter("out.log"))
+            var fileHandler = new FileHandler();
+            string outPath = fileHandler.PathTo("out.log");
+            string errorPath = fileHandler.PathTo("error.log");
+
+            using (StreamWriter outputWriter = new StreamWriter(outPath))
             {
-                using (StreamWriter errorWriter = new StreamWriter("error.log"))
+                using (StreamWriter errorWriter = new StreamWriter(errorPath))
                 {
                     Console.SetOut(outputWriter);
                     Console.SetError(errorWriter);
@@ -56,7 +60,7 @@ namespace parcl
                             exampleConfig.IncludesJre = false;
 
                             XmlSerializer xmlWriter = new XmlSerializer(exampleConfig.GetType());
-                            using (FileStream writer = File.OpenWrite(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "application.example.xml")))
+                            using (FileStream writer = File.OpenWrite(fileHandler.PathTo("application.example.xml")))
                             {
                                 xmlWriter.Serialize(writer, exampleConfig);
                             }

--- a/natives/windows/parcl.csproj
+++ b/natives/windows/parcl.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FileHandler.cs" />
     <Compile Include="JavaApplicationConfig.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
I created an installer for a packaged program using Inno Setup, but I found that the program fails silently when installed to `C:\Program Files (x86)` because it lacks write permissions and cannot write to its log files.

This pull request fixes the issue by adding a `FileHandler` class which decides upon a suitable directory to write files into. It will check whether the folder containing the .exe can be written to, and fall back to a folder in `%AppData%` if write permissions are not available.

If `AppData` is used, the folder will be `C:\Users\%username%\AppData\Roaming\TestProgram` for a packaged program named `TestProgram.exe`. The folder will be created if it does not exist.