### PR TITLE
Fix Gradle 7 compatibility

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[1.7.2]
+- Fix compatibility with Gradle 7.x
+
 [1.7.1]
 - Fix appbundler task not referencing ant project correctly
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = 'org.mini2Dx'
-version = '1.7.1'
+version = '1.7.2'
 description = 'Gradle plugin for bundling your Java application for distribution on Windows, Mac and Linux'
 
 dependencies {

--- a/src/main/groovy/org/mini2Dx/parcl/task/AppBundleTask.groovy
+++ b/src/main/groovy/org/mini2Dx/parcl/task/AppBundleTask.groovy
@@ -23,12 +23,11 @@
  */
 package org.mini2Dx.parcl.task
 
+import com.oracle.appbundler.AppBundlerTask
 import org.apache.tools.ant.types.FileSet
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-
-import com.oracle.appbundler.AppBundlerTask
 
 /**
  * Task for bundling applications into a .app for Mac OS X
@@ -80,8 +79,8 @@ class AppBundleTask extends DefaultTask {
         appBundlerTask.applicationCategory = project.getExtensions().findByName('parcl').app.applicationCategory
         appBundlerTask.displayName = project.getExtensions().findByName('parcl').app.displayName
         appBundlerTask.identifier = project.getExtensions().findByName('parcl').app.identifier
-        appBundlerTask.mainClassName = project.convention.plugins.application.mainClassName
-        
+        appBundlerTask.mainClassName = project.getExtensions().findByName("application").mainClassName
+
 		String javaHome = project.getExtensions().findByName('parcl').app.javaHome
         if(javaHome != null) {
             com.oracle.appbundler.Runtime runtimeFileSet = new com.oracle.appbundler.Runtime()
@@ -105,7 +104,8 @@ class AppBundleTask extends DefaultTask {
         }
         outputDirectory.mkdir()
     }
-    
+
+    @OutputDirectory
     File getOutputJarsDirectory() {
         File installDir = new File(project.getBuildDir(), "install")
         File projectInstallDir = new File(installDir, project.name)

--- a/src/main/groovy/org/mini2Dx/parcl/task/ExeBundleTask.groovy
+++ b/src/main/groovy/org/mini2Dx/parcl/task/ExeBundleTask.groovy
@@ -94,7 +94,7 @@ class ExeBundleTask extends DefaultTask {
 		writer.println("<?xml version=\"1.0\"?>")
 		writer.println("<application xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">")
 
-		writer.println("<mainClassName>" + project.convention.plugins.application.mainClassName + "</mainClassName>")
+		writer.println("<mainClassName>" + project.extensions.findByName("application").mainClassName + "</mainClassName>")
 		writer.println("<includesJre>" + includeJre + "</includesJre>")
 
 		if(project.getExtensions().findByName('parcl').exe.processPriority != null &&
@@ -139,6 +139,7 @@ class ExeBundleTask extends DefaultTask {
 		outputDirectory.mkdir()
 	}
 
+	@OutputDirectory
 	File getOutputJarsDirectory() {
 		File installDir = new File(project.getBuildDir(), "install")
 		File projectInstallDir = new File(installDir, project.name)

--- a/src/main/groovy/org/mini2Dx/parcl/task/LinuxBundleTask.groovy
+++ b/src/main/groovy/org/mini2Dx/parcl/task/LinuxBundleTask.groovy
@@ -23,6 +23,7 @@
  */
 package org.mini2Dx.parcl.task
 
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.mini2Dx.parcl.ParclUtils
 import com.github.mustachejava.DefaultMustacheFactory
@@ -125,10 +126,12 @@ class LinuxBundleTask extends DefaultTask {
 		return new File(projectInstallDir, "lib")
 	}
 
+	@Input
 	String getVmArgs() {
 		return getArgs(project.getExtensions().findByName('parcl').linux.vmArgs)
 	}
 
+	@Input
 	String getAppArgs() {
 		return getArgs(project.getExtensions().findByName('parcl').linux.appArgs)
 	}

--- a/src/main/groovy/org/mini2Dx/parcl/task/LinuxBundleTask.groovy
+++ b/src/main/groovy/org/mini2Dx/parcl/task/LinuxBundleTask.groovy
@@ -91,7 +91,7 @@ class LinuxBundleTask extends DefaultTask {
 		scopes.put("includesJre", includesJre)
 		scopes.put("vmArgs", getVmArgs())
 		scopes.put("appArgs", getAppArgs())
-		scopes.put("mainClassName", project.convention.plugins.application.mainClassName)
+		scopes.put("mainClassName", project.extensions.findByName("application").mainClassName)
 		scopes.put("classpath", getClasspath(outputDirectory))
 
 		try {
@@ -118,6 +118,7 @@ class LinuxBundleTask extends DefaultTask {
 		outputDirectory.mkdir()
 	}
 
+	@OutputDirectory
 	File getOutputJarsDirectory() {
 		File installDir = new File(project.getBuildDir(), "install")
 		File projectInstallDir = new File(installDir, project.name)


### PR DESCRIPTION
This PR makes changes to fix Gradle 7 compatibility: 

- Adds  (now compulsory) task property I/O annotations. 

I also made a change to obtain the main class name by `project.extensions.findByName("application").mainClassName`. This fixed the error referenced on the README for me, and I can't see any problem with doing it this way from first glance. 

I should also mention there are some deprecation warnings for Gradle 8 removals, but the minimum gradle version will need to be bumped to 5.1 to use the replacement methods.